### PR TITLE
Modify #index in sales and purchase transactions controller

### DIFF
--- a/app/controllers/api/v1/purchase_transactions_controller.rb
+++ b/app/controllers/api/v1/purchase_transactions_controller.rb
@@ -1,7 +1,13 @@
 class Api::V1::PurchaseTransactionsController < ApplicationController
   def index
     @purchase_transactions = PurchaseTransaction.all
-    render json: @purchase_transactions
+    purchase_transactions = @purchase_transactions.map do |purchase_transaction|
+      [
+        purchase_transaction,
+        purchase_transaction.purchases
+      ]
+    end
+    render json: purchase_transactions
   end
 
   def create

--- a/app/controllers/api/v1/sales_transactions_controller.rb
+++ b/app/controllers/api/v1/sales_transactions_controller.rb
@@ -1,13 +1,13 @@
 class Api::V1::SalesTransactionsController < ApplicationController
   def index
     @sales_transactions = SalesTransaction.all
-    sales_transactions = @sales_transactions.map do |transaction|
-      {
-        transaction:,
-        sales: Sale.where(transaction_number: transaction.transaction_number)
-      }
+    sales_transactions = @sales_transactions.map do |sales_transaction|
+      [
+        sales_transaction,
+        sales_transaction.sales
+      ]
     end
-    render json: sales_transactions.compact
+    render json: sales_transactions
   end
 
   def create


### PR DESCRIPTION
> Hello @sentayhu19 , I just made some modifications in the sales and purchase transactions controller, 

- Previously it only returns the transactions but now it returns the transactions and the sales and purchases happen in that specific transactions.

         [
          [
            {
              "id": 2,
              "customer_id": 1,
              "transaction_number": "tra-1",
              "reference_number": "ref-1",
              "po_number": "po-1",
              "delivery_number": "del-1",
              "date": "2022-10-22T00:00:00.000Z",
              "received_by": "rec-1",
              "status": "cash",
              "vat": "1.0",
              "withold": "1.0",
              "other_costs": "200.0",
              "created_at": "2023-01-03T16:50:40.803Z",
              "updated_at": "2023-01-03T16:50:40.803Z"
            },
            [
              {
                "id": 2,
                "stock_id": 1,
                "product_id": 1,
                "sales_transaction_id": 2,
                "quantity": 6,
                "price": "350.0",
                "created_at": "2023-01-03T16:54:36.799Z",
                "updated_at": "2023-01-03T16:54:36.799Z"
              }
            ]
          ]
        ]